### PR TITLE
Upgrade stdlib, replace Iterator with Yielder, use assert in tests

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -14,6 +14,7 @@ repository = { type = "github", user = "chiefnoah", repo = "cbor_gl" }
 
 [dependencies]
 gleam_stdlib = "~> 0.36 or ~> 1.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
 ]
 
 [requirements]
 gleam_stdlib = { version = "~> 0.36 or ~> 1.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gleebor.gleam
+++ b/src/gleebor.gleam
@@ -1,6 +1,6 @@
 import gleam/bit_array.{to_string}
-import gleam/iterator.{type Iterator, type Step, Done, Next}
 import gleam/result.{replace_error, try}
+import gleam/yielder.{type Step, type Yielder, Done, Next}
 
 pub type CborError {
   /// Indicates the input ended prematurely and decoding could not continue.
@@ -95,13 +95,13 @@ pub fn decode_string(a: BitArray) -> DecodeResult(String) {
 pub fn decode_list(
   buffer a: BitArray,
   with f: fn(BitArray) -> DecodeResult(t),
-) -> Result(Iterator(DecodeResult(t)), CborError) {
+) -> Result(Yielder(DecodeResult(t)), CborError) {
   case a {
     <<4:3, rest:bits>> -> {
       use #(count, rest) <- try(decode_positive_int(rest))
       // TODO: refactor this to be less ugly
       Ok(
-        iterator.unfold(#(count, rest), fn(n: #(Int, BitArray)) -> Step(
+        yielder.unfold(#(count, rest), fn(n: #(Int, BitArray)) -> Step(
           DecodeResult(t),
           #(Int, BitArray),
         ) {

--- a/test/gleebor_test.gleam
+++ b/test/gleebor_test.gleam
@@ -1,120 +1,81 @@
 import gleebor
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
 }
 
-// gleeunit test functions end in `_test`
 pub fn decode_simple_number_test() {
-  gleebor.decode_int(<<0:3, 13:5>>)
-  |> should.be_ok()
-  |> should.equal(#(13, <<>>))
-  gleebor.decode_int(<<0:3>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<0:3, 13:5>>) == Ok(#(13, <<>>))
+  assert gleebor.decode_int(<<0:3>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_u8_test() {
-  gleebor.decode_int(<<0:3, 24:5, 7:8>>)
-  |> should.be_ok()
-  |> should.equal(#(7, <<>>))
-  gleebor.decode_int(<<0:3, 24:5>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<0:3, 24:5, 7:8>>) == Ok(#(7, <<>>))
+  assert gleebor.decode_int(<<0:3, 24:5>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_u16_test() {
-  gleebor.decode_int(<<0:3, 25:5, 6:16>>)
-  |> should.be_ok()
-  |> should.equal(#(6, <<>>))
-  gleebor.decode_int(<<0:3, 25:5, 6:8>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<0:3, 25:5, 6:16>>) == Ok(#(6, <<>>))
+  assert gleebor.decode_int(<<0:3, 25:5, 6:8>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_u32_test() {
-  gleebor.decode_int(<<0:3, 26:5, 5:32>>)
-  |> should.be_ok()
-  |> should.equal(#(5, <<>>))
-  gleebor.decode_int(<<0:3, 26:5, 5:16>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<0:3, 26:5, 5:32>>) == Ok(#(5, <<>>))
+  assert gleebor.decode_int(<<0:3, 26:5, 5:16>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_u64_test() {
-  gleebor.decode_int(<<0:3, 27:5, 4:64>>)
-  |> should.be_ok()
-  |> should.equal(#(4, <<>>))
-  gleebor.decode_int(<<0:3, 27:5, 4:32>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<0:3, 27:5, 4:64>>) == Ok(#(4, <<>>))
+  assert gleebor.decode_int(<<0:3, 27:5, 4:32>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_simple_negative_number_test() {
-  gleebor.decode_int(<<1:3, 13:5>>)
-  |> should.be_ok()
-  |> should.equal(#(-12, <<>>))
-  gleebor.decode_int(<<1:3>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<1:3, 13:5>>) == Ok(#(-12, <<>>))
+  assert gleebor.decode_int(<<1:3>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u8_test() {
-  gleebor.decode_int(<<1:3, 24:5, 7:8>>)
-  |> should.be_ok()
-  |> should.equal(#(-6, <<>>))
-  gleebor.decode_int(<<1:3, 24:5>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<1:3, 24:5, 7:8>>) == Ok(#(-6, <<>>))
+  assert gleebor.decode_int(<<1:3, 24:5>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u16_test() {
-  gleebor.decode_int(<<1:3, 25:5, 6:16>>)
-  |> should.be_ok()
-  |> should.equal(#(-5, <<>>))
-  gleebor.decode_int(<<1:3, 25:5, 6:8>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<1:3, 25:5, 6:16>>) == Ok(#(-5, <<>>))
+  assert gleebor.decode_int(<<1:3, 25:5, 6:8>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u32_test() {
-  gleebor.decode_int(<<1:3, 26:5, 5:32>>)
-  |> should.be_ok()
-  |> should.equal(#(-4, <<>>))
-  gleebor.decode_int(<<1:3, 26:5, 5:16>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<1:3, 26:5, 5:32>>) == Ok(#(-4, <<>>))
+  assert gleebor.decode_int(<<1:3, 26:5, 5:16>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u64_test() {
-  gleebor.decode_int(<<1:3, 27:5, 4:64>>)
-  |> should.be_ok()
-  |> should.equal(#(-3, <<>>))
-  gleebor.decode_int(<<1:3, 27:5, 4:32>>)
-  |> should.be_error()
+  assert gleebor.decode_int(<<1:3, 27:5, 4:64>>) == Ok(#(-3, <<>>))
+  assert gleebor.decode_int(<<1:3, 27:5, 4:32>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_byte_string_test() {
   // a small byte array
-  gleebor.decode_bytes(<<2:3, 1:5, 123>>)
-  |> should.be_ok()
-  |> should.equal(#(<<123>>, <<>>))
+  assert gleebor.decode_bytes(<<2:3, 1:5, 123>>) == Ok(#(<<123>>, <<>>))
   // a larger one, uses a u8
-  gleebor.decode_bytes(<<
+  let large_byte_string = <<
     2:3, 24:5, 32:8, 78:int-size(64), 78:int-size(64), 78:int-size(64),
     78:int-size(64),
-  >>)
-  |> should.be_ok()
-  |> should.equal(
-    #(
-      <<78:int-size(64), 78:int-size(64), 78:int-size(64), 78:int-size(64)>>,
-      <<>>,
-    ),
-  )
+  >>
+  let expected = <<
+    78:int-size(64), 78:int-size(64), 78:int-size(64), 78:int-size(64),
+  >>
+  assert gleebor.decode_bytes(large_byte_string) == Ok(#(expected, <<>>))
 }
 
 pub fn decode_uft8_string_test() {
   // a small byte array
-  gleebor.decode_string(<<3:3, 1:5, "N":utf8>>)
-  |> should.be_ok()
-  |> should.equal(#("N", <<>>))
+  assert gleebor.decode_string(<<3:3, 1:5, "N":utf8>>) == Ok(#("N", <<>>))
   // a larger one, uses a u8
-  gleebor.decode_string(<<
+  let large_string = <<
     3:3, 24:5, 36:8, "Hello, world! This is a long string!":utf8,
-  >>)
-  |> should.be_ok()
-  |> should.equal(#("Hello, world! This is a long string!", <<>>))
+  >>
+  let expected = "Hello, world! This is a long string!"
+  assert gleebor.decode_string(large_string) == Ok(#(expected, <<>>))
 }

--- a/test/gleebor_test_aggregates.gleam
+++ b/test/gleebor_test_aggregates.gleam
@@ -1,60 +1,49 @@
-import gleam/iterator
+import gleam/result
+import gleam/yielder
 import gleebor
-import gleeunit
-import gleeunit/should
-
-pub fn main() {
-  gleeunit.main()
-}
 
 pub fn decode_byte_string_test() {
   // a small byte array
-  gleebor.decode_bytes(<<2:3, 1:5, 123>>)
-  |> should.be_ok()
-  |> should.equal(#(<<123>>, <<>>))
+  assert gleebor.decode_bytes(<<2:3, 1:5, 123>>) == Ok(#(<<123>>, <<>>))
   // a larger one, uses a u8
-  gleebor.decode_bytes(<<
+  let larger_string = <<
     2:3, 24:5, 32:8, 78:int-size(64), 78:int-size(64), 78:int-size(64),
     78:int-size(64),
-  >>)
-  |> should.be_ok()
-  |> should.equal(
-    #(
-      <<78:int-size(64), 78:int-size(64), 78:int-size(64), 78:int-size(64)>>,
-      <<>>,
-    ),
-  )
+  >>
+  let expected = <<
+    78:int-size(64), 78:int-size(64), 78:int-size(64), 78:int-size(64),
+  >>
+  assert gleebor.decode_bytes(larger_string) == Ok(#(expected, <<>>))
 }
 
 pub fn decode_uft8_string_test() {
   // a small byte array
-  gleebor.decode_string(<<3:3, 1:5, "N":utf8>>)
-  |> should.be_ok()
-  |> should.equal(#("N", <<>>))
+  assert gleebor.decode_string(<<3:3, 1:5, "N":utf8>>) == Ok(#("N", <<>>))
   // a larger one, uses a u8
-  gleebor.decode_string(<<
+
+  let larger_string = <<
     3:3, 24:5, 36:8, "Hello, world! This is a long string!":utf8,
-  >>)
-  |> should.be_ok()
-  |> should.equal(#("Hello, world! This is a long string!", <<>>))
+  >>
+  assert gleebor.decode_string(larger_string)
+    == Ok(#("Hello, world! This is a long string!", <<>>))
 }
 
 pub fn decode_list_ints_test() {
-  gleebor.decode_list(<<4:3, 3:5, 5:8, 4:8, 3:8>>, with: gleebor.decode_int)
-  |> should.be_ok()
-  |> iterator.map(fn(r) {
-    let #(val, _) = should.be_ok(r)
-    val
-  })
-  |> iterator.to_list
-  |> should.equal([5, 4, 3])
+  let cbor_list = <<4:3, 3:5, 5:8, 4:8, 3:8>>
+  assert gleebor.decode_list(cbor_list, with: gleebor.decode_int)
+    |> result.unwrap(yielder.empty())
+    |> yielder.map(fn(r) {
+      let assert Ok(#(val, _)) = r
+      val
+    })
+    |> yielder.to_list
+    == [5, 4, 3]
 }
 
 pub fn decode_list_strings_failure_test() {
-  gleebor.decode_list(<<4:3, 3:5, 5:8, 4:8, 3:8>>, with: gleebor.decode_string)
-  |> should.be_ok()
-  |> iterator.first()
-  |> should.be_ok()
-  |> should.be_error()
-  |> should.equal(gleebor.InvalidMajorArg(0))
+  let cbor_list = <<4:3, 3:5, 5:8, 4:8, 3:8>>
+  let assert Ok(lazily_decoding) =
+    gleebor.decode_list(cbor_list, with: gleebor.decode_string)
+  let assert Ok(first_decoded) = yielder.first(lazily_decoding)
+  assert first_decoded == Error(gleebor.InvalidMajorArg(0))
 }


### PR DESCRIPTION
This PR does some maintenance:

  - upgrade libs
  - introduce [`gleam_yielder`](https://hexdocs.pm/gleam_yielder/gleam/yielder.html#yield) as a replacement for `Iterator`, which was [deprecated in `gleam_stdlib@0.49.0`](https://hexdocs.pm/gleam_stdlib/0.49.0/gleam/iterator.html)
  - change tests so that they use the [`assert`](https://gleam.run/news/gleam-javascript-gets-30-percent-faster#Testing-with-assert) keyword instead of the deprecated functions from the `should` module