### PR TITLE
Bugfix/2/int decoding

### DIFF
--- a/src/gleebor.gleam
+++ b/src/gleebor.gleam
@@ -44,14 +44,14 @@ fn decode_positive_int(a: BitArray) -> DecodeResult(Int) {
 fn decode_negative_int(a: BitArray) -> DecodeResult(Int) {
   case a {
     <<24:int-size(5), val:int-unsigned-size(8), rest:bits>> ->
-      Ok(#(1 - val, rest))
+      Ok(#(-1 - val, rest))
     <<25:int-size(5), val:int-unsigned-size(16), rest:bits>> ->
-      Ok(#(1 - val, rest))
+      Ok(#(-1 - val, rest))
     <<26:int-size(5), val:int-unsigned-size(32), rest:bits>> ->
-      Ok(#(1 - val, rest))
+      Ok(#(-1 - val, rest))
     <<27:int-size(5), val:int-unsigned-size(64), rest:bits>> ->
-      Ok(#(1 - val, rest))
-    <<x:int-size(5), rest:bits>> if x < 24 -> Ok(#(1 - x, rest))
+      Ok(#(-1 - val, rest))
+    <<x:int-size(5), rest:bits>> if x < 24 -> Ok(#(-1 - x, rest))
     <<x:int-size(5), _:bits>> if 27 < x -> Error(InvalidMajorArg(x))
     _ -> Error(PrematureEOF)
   }

--- a/test/gleebor_test.gleam
+++ b/test/gleebor_test.gleam
@@ -31,27 +31,29 @@ pub fn decode_u64_test() {
 }
 
 pub fn decode_simple_negative_number_test() {
-  assert gleebor.decode_int(<<1:3, 13:5>>) == Ok(#(-12, <<>>))
+  assert gleebor.decode_int(<<1:3, 11:5>>) == Ok(#(-12, <<>>))
   assert gleebor.decode_int(<<1:3>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u8_test() {
-  assert gleebor.decode_int(<<1:3, 24:5, 7:8>>) == Ok(#(-6, <<>>))
+  assert gleebor.decode_int(<<1:3, 24:5, 7:8>>) == Ok(#(-8, <<>>))
   assert gleebor.decode_int(<<1:3, 24:5>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u16_test() {
-  assert gleebor.decode_int(<<1:3, 25:5, 6:16>>) == Ok(#(-5, <<>>))
+  assert gleebor.decode_int(<<1:3, 25:5, 4:16>>) == Ok(#(-5, <<>>))
+  // Example from the spec, see https://www.rfc-editor.org/rfc/rfc8949.html#name-major-types
+  assert gleebor.decode_int(<<1:3, 25:5, 499:16>>) == Ok(#(-500, <<>>))
   assert gleebor.decode_int(<<1:3, 25:5, 6:8>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u32_test() {
-  assert gleebor.decode_int(<<1:3, 26:5, 5:32>>) == Ok(#(-4, <<>>))
+  assert gleebor.decode_int(<<1:3, 26:5, 4:32>>) == Ok(#(-5, <<>>))
   assert gleebor.decode_int(<<1:3, 26:5, 5:16>>) == Error(gleebor.PrematureEOF)
 }
 
 pub fn decode_negative_u64_test() {
-  assert gleebor.decode_int(<<1:3, 27:5, 4:64>>) == Ok(#(-3, <<>>))
+  assert gleebor.decode_int(<<1:3, 27:5, 4:64>>) == Ok(#(-5, <<>>))
   assert gleebor.decode_int(<<1:3, 27:5, 4:32>>) == Error(gleebor.PrematureEOF)
 }
 


### PR DESCRIPTION
This PR fixes the wrong decoding of negative integer values. It was previously off by two due to a wrong calculation. A negative integer's value is calculated correctly with the formula `-1 - x`, previously this was `1 - x`. See also #2.